### PR TITLE
Add a gallery JupyterHub service

### DIFF
--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -7,5 +7,11 @@ setup(
         "console_scripts": ["build-gallery-images = tljh_voila_gallery.build_images:main"]
     },
     packages=find_packages(),
-    include_package_data=True
+    include_package_data=True,
+    install_requires=[
+        # These get installed into the hub environment
+        'dockerspawner',
+        'binderhub',
+        'nullauthenticator'
+    ]
 )

--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -11,6 +11,7 @@ setup(
     install_requires=[
         # These get installed into the hub environment
         'dockerspawner',
+        'jupyter-repo2docker',
         'binderhub',
         'nullauthenticator'
     ]

--- a/tljh-voila-gallery/tljh_voila_gallery/__init__.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/__init__.py
@@ -1,4 +1,5 @@
 import socket
+import sys
 import os
 import jinja2
 from pkg_resources import resource_stream, resource_filename
@@ -69,7 +70,7 @@ def tljh_custom_jupyterhub_config(c):
         'admin': True,
         'url': 'http://127.0.0.1:9888',
         'command': [
-            'python3', '-m', 'tljh_voila_gallery.gallery'
+            sys.executable, '-m', 'tljh_voila_gallery.gallery'
         ]
     }]
 

--- a/tljh-voila-gallery/tljh_voila_gallery/__init__.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/__init__.py
@@ -31,9 +31,11 @@ def options_form(spawner):
 @hookimpl
 def tljh_custom_jupyterhub_config(c):
     from dockerspawner import DockerSpawner
+    from nullauthenticator import NullAuthenticator
     class GallerySpawner(DockerSpawner):
         # FIXME: What to do about idle culling?!
         cmd = 'jupyter-notebook'
+
         events = False
 
         def get_args(self):
@@ -54,8 +56,15 @@ def tljh_custom_jupyterhub_config(c):
             self.image = self.user_options['image']
             return super().start()
 
+
+    class GalleryAuthenticator(NullAuthenticator):
+        auto_login = True
+
+        def login_url(self, base_url):
+            return '/services/gallery'
+
     c.JupyterHub.spawner_class = GallerySpawner
-    c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+    c.JupyterHub.authenticator_class = GalleryAuthenticator
 
     c.JupyterHub.hub_connect_ip = socket.gethostname()
 

--- a/tljh-voila-gallery/tljh_voila_gallery/__init__.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/__init__.py
@@ -67,14 +67,6 @@ def tljh_custom_jupyterhub_config(c):
 
     c.Spawner.options_form = options_form
 
-
-@hookimpl
-def tljh_extra_hub_pip_packages():
-    return [
-        'dockerspawner',
-        'git+https://github.com/jupyter/repo2docker.git@f19e159dfe1006dbd82c7728e15cdd19751e8aec'
-    ]
-
 @hookimpl
 def tljh_extra_apt_packages():
     return [

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -1,0 +1,63 @@
+import os
+from tornado import ioloop, web
+from pkg_resources import resource_stream, resource_filename
+from ruamel.yaml import YAML
+from jinja2 import PackageLoader, Environment
+import json
+from binderhub.launcher import Launcher
+
+yaml = YAML()
+
+# Read gallery.yaml on each spawn. If this gets too expensive, cache it here
+def get_gallery():
+    with resource_stream(__name__, 'gallery.yaml') as f:
+        return yaml.load(f)
+
+templates = Environment(loader=PackageLoader('tljh_voila_gallery', 'templates'))
+
+class GalleryHandler(web.RequestHandler):
+    def get(self):
+        gallery_template = templates.get_template('gallery-examples.html')
+        gallery = get_gallery()
+
+        self.write(gallery_template.render(
+            url=self.request.full_url(),
+            examples=gallery.get('examples', [])
+        ))
+
+    async def post(self):
+        gallery = get_gallery()
+
+        example_name = self.get_body_argument('example')
+
+        example = gallery['examples'][example_name]
+
+
+        launcher = Launcher(
+            hub_api_token=os.environ['JUPYTERHUB_API_TOKEN'],
+            hub_url=os.environ['JUPYTERHUB_BASE_URL']
+        )
+        response = await launcher.launch(
+            example['image'],
+            launcher.unique_name_from_repo(example['repo_url'])
+        )
+        print(json.dumps(example) + '\n', flush=True)
+        print(json.dumps(response), flush=True)
+        # FIXME: urljoin here
+        self.redirect(
+            response['url'] + '?' + 'token=' + response['token']
+        )
+        
+
+def make_app():
+    print(os.environ['JUPYTERHUB_SERVICE_PREFIX'], flush=True)
+    return web.Application([
+        (os.environ['JUPYTERHUB_SERVICE_PREFIX'] + '/?', GalleryHandler),
+    ])
+
+if __name__ == "__main__":
+    if not os.environ['JUPYTERHUB_API_URL'].endswith('/'):
+        os.environ['JUPYTERHUB_API_URL'] = os.environ['JUPYTERHUB_API_URL'] + '/'
+    app = make_app()
+    app.listen(9888)
+    ioloop.IOLoop.current().start()

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -5,6 +5,7 @@ from ruamel.yaml import YAML
 from jinja2 import PackageLoader, Environment
 import json
 from binderhub.launcher import Launcher
+from urllib.parse import urljoin, urlencode
 
 yaml = YAML()
 
@@ -43,10 +44,11 @@ class GalleryHandler(web.RequestHandler):
         )
         print(json.dumps(example) + '\n', flush=True)
         print(json.dumps(response), flush=True)
-        # FIXME: urljoin here
-        self.redirect(
-            response['url'] + '?' + 'token=' + response['token']
-        )
+        redirect_url = urljoin(
+            response['url'],
+            example['url']
+        ) +  '?' + urlencode({'token': response['token']})
+        self.redirect(redirect_url)
         
 
 def make_app():

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -42,8 +42,6 @@ class GalleryHandler(web.RequestHandler):
             example['image'],
             launcher.unique_name_from_repo(example['repo_url'])
         )
-        print(json.dumps(example) + '\n', flush=True)
-        print(json.dumps(response), flush=True)
         redirect_url = urljoin(
             response['url'],
             example['url']
@@ -52,7 +50,6 @@ class GalleryHandler(web.RequestHandler):
         
 
 def make_app():
-    print(os.environ['JUPYTERHUB_SERVICE_PREFIX'], flush=True)
     return web.Application([
         (os.environ['JUPYTERHUB_SERVICE_PREFIX'] + '/?', GalleryHandler),
     ])

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -3,20 +3,20 @@ examples:
     title: country-indicators
     description: Explore the correlations between indicators of development using matplotlib and ipywidgets
     image: country-indicators:latest
-    url: /voila/render/index.ipynb
+    url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/voila-gallery-country-indicators
     image_url: https://i.imgur.com/IeG75O3.png
   gaussian-density:
     title: gaussian-density
     description: Explore the normal distribution interactively with bqplot
     image: gaussian-density:latest
-    url: /voila/render/index.ipynb
+    url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/gaussian-density
     image_url: https://i.imgur.com/J1Mj6rc.png
   render-stl:
     title: render-stl
     description: Explore STL files with ipyvolume
     image: render-stl:latest
-    url: /voila/render/index.ipynb
+    url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/render-stl
     image_url: https://github.com/voila-gallery/render-stl/raw/master/thumbnail.png

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/gallery-examples.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/gallery-examples.html
@@ -1,3 +1,7 @@
+{% extends "page.html" %}
+
+{% block body %}
+        <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
 <div class="row">
 {% for example_name, info in examples.items() %}
         <div class="col-md-4">
@@ -18,3 +22,7 @@
         </div>
 {% endfor %}
 </div>
+
+        </form>
+
+{% endblock %}

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
@@ -81,10 +81,8 @@
 
   <div class="album py-5 bg-light">
     <div class="container">
-
-        <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
-           {{spawner_options_form | safe}}
-        </form>
+      {% block body %}
+      {% endblock %}
     </div>
   </div>
 


### PR DESCRIPTION
This unauthenticated hub service can render our
gallery page easily, and launch a new user + server
per gallery launch. This solves a number of problems:

1. Letting users view multiple galleries at once, without
   having to do complex things with named servers
2. Back button works correctly, since it no longer sends you
   to the spawn page (Fixes #3)
3. Much easier to iterate and work on, since this is just a
   tornado application
4. We have full access to the hub API, which can be very useful

Putting this in /hub/spawn was a hack, and IMO making this
into a service is the 'right' thing to do

Todo:
- [x] Integrate this into the TLJH plugin
- [x] Figure out what to do about binderhub dependency
- [x] Make this the 'home page' when people visit the domain