### PR TITLE
Remove extrenous 'image' field from gallery.yaml

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/build_images.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/build_images.py
@@ -48,9 +48,9 @@ def build_image(example):
 def parse_gallery_config(fp):
     config = yaml.load(fp)
     examples = []
-    for example_yaml in config['examples'].values():
+    for example_name, example_yaml in config['examples'].items():
         example = Example(
-            image=example_yaml['image'],
+            image=f'{example_name}:latest',
             repo_url=example_yaml['repo_url']
         )
         examples.append(example)

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -39,7 +39,7 @@ class GalleryHandler(web.RequestHandler):
             hub_url=os.environ['JUPYTERHUB_BASE_URL']
         )
         response = await launcher.launch(
-            example['image'],
+            f'{example_name}:latest',
             launcher.unique_name_from_repo(example['repo_url'])
         )
         redirect_url = urljoin(

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -2,21 +2,18 @@ examples:
   country-indicators:
     title: country-indicators
     description: Explore the correlations between indicators of development using matplotlib and ipywidgets
-    image: country-indicators:latest
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/voila-gallery-country-indicators
     image_url: https://i.imgur.com/IeG75O3.png
   gaussian-density:
     title: gaussian-density
     description: Explore the normal distribution interactively with bqplot
-    image: gaussian-density:latest
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/gaussian-density
     image_url: https://i.imgur.com/J1Mj6rc.png
   render-stl:
     title: render-stl
     description: Explore STL files with ipyvolume
-    image: render-stl:latest
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/render-stl
     image_url: https://github.com/voila-gallery/render-stl/raw/master/thumbnail.png


### PR DESCRIPTION
We can use the example name instead