### PR TITLE
Use request uri for the form action

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -22,7 +22,7 @@ class GalleryHandler(web.RequestHandler):
         gallery = get_gallery()
 
         self.write(gallery_template.render(
-            url=self.request.full_url(),
+            url=self.request.uri,
             examples=gallery.get('examples', []),
             static_url=self.static_url
         ))


### PR DESCRIPTION
`self.request.full_url` would give an `http` url, which shows warnings to the user when serving [voila-gallery.org](https://voila-gallery.org) with `https`.