### PR TITLE
WIP: Cull idle servers

### DIFF
--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -14,6 +14,6 @@ setup(
         'dockerspawner',
         'jupyter-repo2docker',
         'binderhub',
-        'nullauthenticator'
+        'jupyter-tmpauthenticator'
     ]
 )


### PR DESCRIPTION
Still very much of a wip.

The idea is to switch to running `jupyterhub-singleuser` so we can make use of the activity tracking for the notebook server.

### TODO

- [x] Start notebook server with `jupyterhub-singleuser`
- [ ] Switch to `TmpAuthenticator`
- [ ] Use named servers?

cc @yuvipanda 