### PR TITLE
Add footer to credit OVH for hosting

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/static/style.css
+++ b/tljh-voila-gallery/tljh_voila_gallery/static/style.css
@@ -17,3 +17,7 @@
 .card-text {
 	  min-height: 5em;
 }
+
+.footer {
+    padding-bottom: 10px;
+}

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
@@ -66,6 +66,13 @@
 
 </main>
 <script src="{{ static_url('vendor/bootstrap-4.0.0/js/bootstrap.min.js') }}"></script>
+
+<footer class="footer">
+  <div class="container">
+    <span class="text-muted">Kindly hosted by <a href="https://ovh.com">OVH</a></span>
+  </div>
+</footer>
+
   </body>
 </html>
 


### PR DESCRIPTION
Fixes #22.

Add a footer to credit OVH for hosting the gallery:

![image](https://user-images.githubusercontent.com/591645/60170435-b546ff00-9808-11e9-949d-2de22bb52bf2.png)
 