### PR TITLE
Add xleaflet / C++ example

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -17,3 +17,9 @@ examples:
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/render-stl
     image_url: https://github.com/voila-gallery/render-stl/raw/master/thumbnail.png
+  xleaflet:
+    title: xleaflet
+    description: Interactive maps with xleaflet and the C++ kernel
+    url: voila/render/index.ipynb
+    repo_url: https://github.com/jtpio/voila-gallery-xleaflet
+    image_url: https://github.com/jtpio/voila-gallery-xleaflet/raw/master/thumbnail.png


### PR DESCRIPTION
Add a new example to show that voila can be used with other languages than Python.

This one is for now the same as the [`xleaflet` example from the voila repo](https://github.com/QuantStack/voila/blob/master/notebooks/xleaflet.ipynb), but it could be interesting to build a more complex app combining other C++ widgets such as [xwebrtc](https://github.com/QuantStack/xwebrtc) and [xthreejs](https://github.com/QuantStack/xthreejs). In that case we can rename the example to something more generic such as `xstack`.

Based on the following repo, which can be moved to the voila-gallery organization: https://github.com/jtpio/voila-gallery-xleaflet/