### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can go back to the gallery landing page using the back button of the web bro
    - `repo_url`: the URL of the repository serving as source.
    - `image_url`: the URL of the picture to use as thumbnail.
 
-## Deploying you own gallery
+## Deploying your own gallery
 
 The voila gallery is built as a plugin for [The Littlest JupyterHub (TLJH)](https://tljh.jupyter.org). To deploy your own instance:
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ You can go back to the gallery landing page using the back button of the web bro
    - `url`: the URL of the notebook to render.
    - `repo_url`: the URL of the repository serving as source.
    - `image_url`: the URL of the picture to use as thumbnail.
+
+## Deploying you own gallery
+
+The voila gallery is built as a plugin for [The Littlest JupyterHub (TLJH)](https://tljh.jupyter.org). To deploy your own instance:
+
+1. Fork the gallery repo: https://github.com/voila-gallery/gallery
+2. Edit the `tljh-voila-gallery/tljh_voila_gallery/gallery.yaml` file with your own set of examples
+3. Follow [one of the tutorials to install TLJH](https://tljh.jupyter.org/en/latest/#installation)
+4. At the step asking for user data, use the following command:
+
+```
+#!/bin/bash
+curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
+ | sudo python3 - \
+   --plugin git+https://github.com/<your-username>/gallery@master#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"
+```
+5. The install process might take between 5 and 10 minutes to complete.
+6. Dependending on the method and cloud provider chosen in step 1, you will get the public IP of the server, which can be used to access the gallery

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ View the gallery at [voila-gallery.org](http://voila-gallery.org).
 
 ## Going back to the gallery screen
 
-At the moment, the only way to go back to gallery screen is to hit the
-[/hub/logout](http://voila-gallery.org/hub/logout) endpoint.
+You can go back to the gallery landing page using the back button of the web browser.
 
 ## Contributing new examples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can go back to the gallery landing page using the back button of the web bro
 ## Contributing new examples
 
 1. Create a repository with your notebook. You can start from the [hello-world](https://github.com/voila-gallery/hello-world-example) example.
-2. The gallery launches the examples using Docker containers, similar to what Binder does. This means that [the repository can be first tested on Binder](https://mybinder.readthedocs.io/en/latest/introduction.html#preparing-a-repository-for-binder).
+2. The gallery launches the examples using [repo2docker](https://github.com/jupyter/repo2docker), exactly the same way Binder does. This means that [the repository can be first tested on Binder](https://mybinder.readthedocs.io/en/latest/introduction.html#preparing-a-repository-for-binder).
 2. Test your repository on Binder.
 3. Create a PR to [voila-gallery](https://github.com/voila-gallery/gallery) that
    modifies `tljh-voila-gallery/tljh_voila_gallery/gallery.yaml`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can go back to the gallery landing page using the back button of the web bro
 
 ## Contributing new examples
 
-1. Create a repository with your notebook. You can copy the [gaussian-density](https://github.com/voila-gallery/gaussian-density) example.
+1. Create a repository with your notebook. You can start from the [hello-world](https://github.com/voila-gallery/hello-world-example) example.
 2. The gallery launches the examples using Docker containers, similar to what Binder does. This means that [the repository can be first tested on Binder](https://mybinder.readthedocs.io/en/latest/introduction.html#preparing-a-repository-for-binder).
 2. Test your repository on Binder.
 3. Create a PR to [voila-gallery](https://github.com/voila-gallery/gallery) that

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ You can go back to the gallery landing page using the back button of the web bro
 ## Contributing new examples
 
 1. Create a repository with your notebook. You can copy the [gaussian-density](https://github.com/voila-gallery/gaussian-density) example.
+2. The gallery launches the examples using Docker containers, similar to what Binder does. This means that [the repository can be first tested on Binder](https://mybinder.readthedocs.io/en/latest/introduction.html#preparing-a-repository-for-binder).
 2. Test your repository on Binder.
 3. Create a PR to [voila-gallery](https://github.com/voila-gallery/gallery) that
    modifies `tljh-voila-gallery/tljh_voila_gallery/gallery.yaml`.
    You will need to fill in the following fields:
    - `title`: the title used in the page thumbnail.
    - `description`: the description used in the page thumbnail.
-   - `image`: the name of the built Docker image. This should be `$title:latest`.
    - `url`: the URL of the notebook to render.
    - `repo_url`: the URL of the repository serving as source.
    - `image_url`: the URL of the picture to use as thumbnail.


### PR DESCRIPTION
Fixes #18 

### Changes

- Remove the mention to the `/hub/logout` trick
- Add a section to deploy your own gallery powered by TLJH
- Update section on adding a new example (no need to provide `image` anymore)