### PR TITLE
Add GPX Viewer example to the gallery

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -23,3 +23,9 @@ examples:
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/cpp-xleaflet
     image_url: https://github.com/voila-gallery/cpp-xleaflet/raw/master/thumbnail.png
+  gpx-viewer:
+    title: gpx-viewer
+    description: GPX Viewer web app built with ipywidgets, ipyleaflet, bqplot and voila
+    url: voila/render/app.ipynb
+    repo_url: https://github.com/jtpio/voila-gpx-viewer
+    image_url: https://user-images.githubusercontent.com/591645/60527710-0ff1c680-9cf3-11e9-87b5-8711fd3da344.gif


### PR DESCRIPTION
This adds an example of a GPX Viewer web app built with ipywidgets, ipyleaflet and bqplot.

![](https://user-images.githubusercontent.com/591645/60527710-0ff1c680-9cf3-11e9-87b5-8711fd3da344.gif)

Keeping this example under my account for the moment to show that the gallery support example outside of the voila-gallery organization. We can consider moving it over later.