### PR TITLE
Update the gallery package before building new images

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/install_builder_units.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/install_builder_units.py
@@ -1,7 +1,11 @@
+import os
 import sys
 from pkg_resources import resource_stream
 
 from tljh import systemd
+
+GALLERY_REPO = os.environ.get('GALLERY_REPO', 'git+https://github.com/voila-gallery/gallery@master#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"')
+
 
 def ensure_builder_units():
     gallery_builder_service = 'tljh-voila-gallery-builder.service'
@@ -14,6 +18,7 @@ def ensure_builder_units():
 
     unit_params = dict(
         python_interpreter_path=sys.executable,
+        gallery_repo=GALLERY_REPO,
     )
 
     systemd.install_unit(gallery_builder_service, builder_unit_template.format(**unit_params))

--- a/tljh-voila-gallery/tljh_voila_gallery/systemd-units/tljh-voila-gallery-builder.service
+++ b/tljh-voila-gallery/tljh_voila_gallery/systemd-units/tljh-voila-gallery-builder.service
@@ -11,6 +11,9 @@ PrivateTmp=yes
 PrivateDevices=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
+# Update with the new gallery
+ExecStartPre={python_interpreter_path} -m pip install -U {gallery_repo}
+# Build the new Docker images
 ExecStart={python_interpreter_path} -m tljh_voila_gallery.build_images
 
 [Install]


### PR DESCRIPTION
This PR Implements the idea from https://github.com/voila-gallery/gallery/pull/37#issuecomment-506722023 (option 2) so the gallery can be updated automatically.

It also introduces the `GALLERY_REPO` environment variable to let the users configure where their gallery is located. The full install command for a new installation can then become:

```bash
#!/bin/bash
export GALLERY_REPO=git+https://github.com/<your-username>/gallery@master#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"
curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
 | sudo python3 - \
   --plugin ${GALLERY_REPO}
```

@yuvipanda does the JupyterHub service need to be restarted after updating the package?