### PR TITLE
Remove repo2docker appendix

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/build_images.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/build_images.py
@@ -41,8 +41,6 @@ def build_image(example):
         '--no-run',
         '--image-name',
         example.image,
-        '--appendix',
-        'run ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir voila==0.1.5',
         example.repo_url
     ])
 


### PR DESCRIPTION
All the examples already list `voila` as a requirement, so we should be fine removing this extra install.

Hopefully this will also resolve the few intermittent issues related to the wrong version of `Pygments` being pulled (2.3 instead of 2.4).