### PR TITLE
Add support for refs in gallery.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can go back to the gallery landing page using the back button of the web bro
    - `description`: the description used in the page thumbnail.
    - `url`: the URL of the notebook to render.
    - `repo_url`: the URL of the repository serving as source.
+   - `ref`: the commit hash used to pin to a specific version of the example
    - `image_url`: the URL of the picture to use as thumbnail.
 
 ## Deploying your own gallery

--- a/tljh-voila-gallery/tljh_voila_gallery/build_images.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/build_images.py
@@ -22,7 +22,8 @@ Example = namedtuple(
     'Example',
     [
         'image',
-        'repo_url'
+        'repo_url',
+        'ref'
     ]
 )
 
@@ -33,7 +34,7 @@ def build_image(example):
         '-m',
         'repo2docker',
         '--ref',
-        'master',
+        example.ref,
         '--user-name',
         'jovyan',
         '--user-id',
@@ -51,7 +52,8 @@ def parse_gallery_config(fp):
     for example_name, example_yaml in config['examples'].items():
         example = Example(
             image=f'{example_name}:latest',
-            repo_url=example_yaml['repo_url']
+            repo_url=example_yaml['repo_url'],
+            ref=example_yaml.get('ref', 'master'),
         )
         examples.append(example)
     return examples

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -4,30 +4,35 @@ examples:
     description: Explore the correlations between indicators of development using matplotlib and ipywidgets
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/voila-gallery-country-indicators
+    ref: 7cd5df8169fe6acefe1d5a200f9878e441b9208a
     image_url: https://i.imgur.com/IeG75O3.png
   gaussian-density:
     title: gaussian-density
     description: Explore the normal distribution interactively with bqplot
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/gaussian-density
+    ref: a643a1b180e1892840f4f692115f05a2b6df7bcb
     image_url: https://i.imgur.com/J1Mj6rc.png
   render-stl:
     title: render-stl
     description: Explore STL files with ipyvolume
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/render-stl
+    ref: 23182d099e3b97bce3f64ec383d93ddc4734fe17
     image_url: https://github.com/voila-gallery/render-stl/raw/master/thumbnail.png
   cpp-xleaflet:
     title: cpp-xleaflet
     description: Interactive maps with xleaflet and the C++ kernel
     url: voila/render/index.ipynb
     repo_url: https://github.com/voila-gallery/cpp-xleaflet
+    ref: 86e31eb875b72af62c4168efb53158735104251d
     image_url: https://github.com/voila-gallery/cpp-xleaflet/raw/master/thumbnail.png
   gpx-viewer:
     title: gpx-viewer
     description: GPX Viewer web app built with ipywidgets, ipyleaflet, bqplot and voila
     url: voila/render/app.ipynb
     repo_url: https://github.com/jtpio/voila-gpx-viewer
+    ref: 43771ead52a64ef3afb8adf023c409f560cd272c
     image_url: https://user-images.githubusercontent.com/591645/60527710-0ff1c680-9cf3-11e9-87b5-8711fd3da344.gif
   interactive-football-pitch:
     title: interactive-football-pitch

--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.yaml
@@ -39,10 +39,12 @@ examples:
     description: Interactive football pitch build with voila, qgrid and bqplot.
     url: voila/render/Interactive-Football-Pitch.ipynb
     repo_url: https://github.com/seidlr/voila-interactive-football-pitch
+    ref: 61799617090df7f9c6564927adc3823803f1670e
     image_url: https://i.imgur.com/yuWQZtL.png
   codex-clustergrammer2:
     title: codex-clustergrammer2
     description: CODEX Single Cell Multiplexed Imaging Dashboard
     url: voila/render/index.ipynb
+    ref: 8503231929bbb18cea9ef737a6c14d4c6c3ff04b
     repo_url: https://github.com/ismms-himc/codex_dashboard
     image_url: https://raw.githubusercontent.com/ismms-himc/codex_dashboard/master/img/codex_screenshot.png


### PR DESCRIPTION
Fixes #56. 

- Add support for refs in the `gallery.yaml` file
- This gives us the possibility to pin examples to a specific commit and not rely on the latest from master.
- Updating an example means opening a new PR to update the ref.
- Defaults to master if there is not ref (could be used for the "official" examples in the voila-gallery organization)

It arguably adds a bit of friction but also gives a better view of when an example has been updated.