### PR TITLE
Improve wording in homepage.

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
@@ -25,9 +25,9 @@
     <section class="jumbotron text-center">
       <div class="container">
         <p><img src="{{ static_url('voila-gallery-logo.png') }}" /></p>
-        <p class="lead text-muted">This gallery contains fully interactive examples of interactive Jupyter
-         dashboards and applications rendered by Voila.</p>
-        <p class="lead text-muted">Use these to find inspiration for creating your own dashboard applications.</p>
+        <p class="lead text-muted">This gallery contains examples of fully interactive
+         dashboards rendered from Jupyter notebooks by Voila.</p>
+        <p class="lead text-muted">Use these for inspiration when creating your own dashboard applications.</p>
       </div>
     </section>
 

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
@@ -26,7 +26,7 @@
       <div class="container">
         <p><img src="{{ static_url('voila-gallery-logo.png') }}" /></p>
         <p class="lead text-muted">This gallery contains examples of fully interactive
-         dashboards rendered from Jupyter notebooks by Voila.</p>
+         dashboards rendered from Jupyter notebooks by Voilà.</p>
         <p class="lead text-muted">Use these for inspiration when creating your own dashboard applications.</p>
       </div>
     </section>

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/page.html
@@ -25,8 +25,8 @@
     <section class="jumbotron text-center">
       <div class="container">
         <p><img src="{{ static_url('voila-gallery-logo.png') }}" /></p>
-        <p class="lead text-muted">This gallery contains examples of fully interactive
-         dashboards rendered from Jupyter notebooks by Voilà.</p>
+        <p class="lead text-muted">This gallery contains examples of Jupyter notebooks
+         turned into standalone web applications by Voilà.</p>
         <p class="lead text-muted">Use these for inspiration when creating your own dashboard applications.</p>
       </div>
     </section>


### PR DESCRIPTION
Hello @jtpio,

Navigating https://voila-gallery.org/services/gallery/, I spotted areas for improvement in the short description at the top of the page.

I considered going even further... because Voilà does not simply *render* Jupyter notebooks in a given way, it *converts* them, it *turns* them *into* standalone web apps.

I'm pondering every word as I'm re-reading the two existing Voilà blog posts and writing...

/cc @SylvainCorlay