### PR TITLE
Make whole badge clickable

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/static/index.js
+++ b/tljh-voila-gallery/tljh_voila_gallery/static/index.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    $('.launch-example').click(function(event) {
+    $('.launch-item').click(function(event) {
         var example = $(event.currentTarget).data('example-name');
         $('#example-' + example).prop('checked', true);
         $('#spawn_form').submit();

--- a/tljh-voila-gallery/tljh_voila_gallery/static/style.css
+++ b/tljh-voila-gallery/tljh_voila_gallery/static/style.css
@@ -1,4 +1,5 @@
 /* Main page areas */
+
 .voila-white {
     background: white;
     color: #222;
@@ -37,7 +38,6 @@
 
 .gallery-item {
   height: 100%;
-  padding: 8px;
   box-shadow: 4px 4px 12px #aaa;
   user-select: none;
 }

--- a/tljh-voila-gallery/tljh_voila_gallery/templates/gallery-examples.html
+++ b/tljh-voila-gallery/tljh_voila_gallery/templates/gallery-examples.html
@@ -6,22 +6,21 @@
     <div class="row no-gutters">
       {% for example_name, info in examples.items() %}
         <div class="col-md-4" style="height: 400px; padding: 16px;">
-          <div class="gallery-item">
-            <img style="height: 50%; width: 100%; object-fit: contain;" src="{{info.image_url}}" />
-            <div style="height: 30%;">
-              <h4 style="margin-top: .5rem; text-overflow: ellipsis; overflow: hidden;   white-space: nowrap;
-
-">{{ info.title }}</h4>
-              <p>{{ info.description }}</p>
-            </div>
-            <div style="height: 20%;">
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="btn-group" style="width: 100%;" >
-                  <input type="radio" name="example" id="example-{{example_name}}" value="{{example_name}}" class="d-none"/>
-                  <button style="width: 50%; overflow: hidden;" type="submit" data-example-name="{{example_name}}" class="launch-example btn">Launch</button>
-                  <a style="width: 50%; overflow: hidden;" href="{{info.repo_url}}" target="_blank" type="button" class="btn btn-secondary">Source</a>
-                </div>
+          <input type="radio" name="example" id="example-{{example_name}}" value="{{example_name}}" class="d-none"/>
+          <div class="gallery-item"> 
+            <div class="launch-item"
+                 style="height: 90%; padding: 8px;"
+                 id="example-{{example_name}}"
+                 value="{{example_name}}"
+                 data-example-name="{{example_name}}">
+              <img style="height: 60%; width: 100%; object-fit: contain;" src="{{info.image_url}}" />
+              <div style="height: 40%; overflow: hidden;">
+                <h4 style="margin-top: .5rem; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;">{{ info.title }}</h4>
+                <p>{{ info.description }}</p>
               </div>
+            </div>
+            <div style="height: 10%;">
+              <a style="height: 100%; width: 100%; color: #333;" href="{{info.repo_url}}" target="_blank" type="button" class="btn btn-light">Source</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This makes the whole badge clickable and removes the "launch" buttons.

Still need to prevent the propagation for the top-level "source" link, except if we put it outside of the badge...

![localhost_8000_services_gallery(QuantStack)](https://user-images.githubusercontent.com/2397974/65722699-0fc45580-e0ad-11e9-95cd-cec9fa36eb4d.png)
