### PR TITLE
Use example name instead of title

### DIFF
--- a/tljh-voila-gallery/tljh_voila_gallery/gallery.py
+++ b/tljh-voila-gallery/tljh_voila_gallery/gallery.py
@@ -29,7 +29,7 @@ def get_gallery():
     images = _get_docker_images()
     gallery['examples'] = {
         name: ex for name, ex in gallery.get('examples', {}).items()
-        if f"{ex.get('title', '')}:latest" in images
+        if f"{name}:latest" in images
     }
     return gallery
 


### PR DESCRIPTION
An example would not be displayed in the gallery when the name is not the same as the title.
 