### PR TITLE
Add GitHub Actions workflow for auto deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy the Voila Gallery
+      uses: appleboy/ssh-action@v0.0.4
+      with:
+        host: ${{ secrets.VOILA_GALLERY_HOST }}
+        username: ${{ secrets.VOILA_GALLERY_SSH_USERNAME }}
+        key: ${{ secrets.VOILA_GALLERY_SSH_PRIVATE_KEY }}
+        script: |
+          sudo /opt/tljh/hub/bin/python3 -m pip install -U  git+https://github.com/voila-dashboards/gallery@master#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"
+          sudo systemctl restart jupyterhub.service
+          sudo systemctl status jupyterhub.service
+
+    - name: Check voila-gallery.org is reachable
+      run: |
+        sleep 5
+        curl -sSf https://voila-gallery.org > /dev/null


### PR DESCRIPTION
Add a GitHub Actions workflow to automatically deploy the gallery when pushing to `master`.

This is a very simple fix https://github.com/voila-dashboards/gallery/issues/57, but good enough for now. We can build on top of that afterwards, or even move the deploy script to the [voila-gallery.org-deploy](https://github.com/voila-gallery/voila-gallery.org-deploy) repo.

This is what the workflow does:

- SSH into the existing instance
- Reinstall the gallery package
- Restart JupyterHub
- Test it's up again after 5 seconds