### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      
+      - name: Install the plugin
+        run: |
+          python -m pip install -e tljh-voila-gallery
+
+      - name: Check repo2docker is installed
+        run: |
+          python -m repo2docker --version


### PR DESCRIPTION
To have a minimal workflow that installs the plugin as a Python package to start with.