### PR TITLE
Install repo2docker from git

### DIFF
--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         # These get installed into the hub environment
         'dockerspawner',
-        'repo2docker @ git+https://github.com/jupyterhub/repo2docker',
+        'jupyter-repo2docker @ git+https://github.com/jupyterhub/repo2docker',
         'binderhub',
         'nullauthenticator'
     ]

--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         # These get installed into the hub environment
         'dockerspawner',
-        'git+https://github.com/jupyterhub/repo2docker@master',
+        'repo2docker @ git+https://github.com/jupyterhub/repo2docker',
         'binderhub',
         'nullauthenticator'
     ]

--- a/tljh-voila-gallery/setup.py
+++ b/tljh-voila-gallery/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         # These get installed into the hub environment
         'dockerspawner',
-        'jupyter-repo2docker',
+        'git+https://github.com/jupyterhub/repo2docker@master',
         'binderhub',
         'nullauthenticator'
     ]


### PR DESCRIPTION
Since it will correspond to the most recent version, and Binder also uses the latest `repo2docker`.